### PR TITLE
Reduce dynamic allocation

### DIFF
--- a/inject.c
+++ b/inject.c
@@ -104,7 +104,10 @@ _mmap_data(int pid, size_t len, void *base_address, int protections, int flags, 
   long shellcode_len = ftell(f);
   CHECK(shellcode_len > 0, "ftell error");
   // align shellcode size to 32/64-bit boundary
-  long shellcode_len_aligned = shellcode_len + (sizeof(void*) - (shellcode_len % sizeof(void*)));
+  long shellcode_len_aligned = shellcode_len;
+  if (shellcode_len % sizeof(void*) != 0) {
+    shellcode_len_aligned += sizeof(void*) - shellcode_len % sizeof(void*);
+  }
   CHECK(fseek(f, 0, SEEK_SET) == 0, "fseek error");
   shellcode = malloc(shellcode_len_aligned);
   memset(shellcode, 0x90, shellcode_len_aligned); // fill with NOPs

--- a/inject.c
+++ b/inject.c
@@ -242,7 +242,7 @@ error:
 int
 inject_code(int pid, unsigned char *payload, size_t payload_len)
 {
-  int ret = 0, status = 0;
+  int ret = 0;
   void *payload_addr = NULL,
        *stack = NULL,
        *code_cave = NULL,


### PR DESCRIPTION
This pull request avoids rounding up the allocation size when already word-aligned, as previously discussed. Sorry it took a while to get back to this one. I've included the removal of an unused variable I spotted along the way. Thanks!
